### PR TITLE
[WB-48] Add configuration for Redis Cluster nodes.

### DIFF
--- a/cache/Cache.js
+++ b/cache/Cache.js
@@ -1,7 +1,8 @@
 const EventEmitter = require('events')
-const _createRedisClient = require('./util/createRedisClient')
 const msgpack = require('msgpack-lite')
 const conflogger = require('conflogger')
+const _createRedisClient = require('./util/createRedisClient')
+const _getCleanArray = require('../models/util/getCleanArray')
 
 // default entry expiration time in seconds
 const DEFAULT_EXPIRATION = 86400
@@ -16,6 +17,8 @@ class Cache extends EventEmitter {
     this._onError = (err) => this.emit('error', err)
     this._onReconnecting = () => this.emit('reconnecting')
     this._onNodeError = (err) => this.emit('node-error', err)
+
+    this._nodes = _getCleanArray(nodes)
 
     const redisClient = this._redisClient =
       _createRedisClient(nodes, redisClientOptions)

--- a/models/cache/RedisClusterNodeConfig.js
+++ b/models/cache/RedisClusterNodeConfig.js
@@ -1,0 +1,13 @@
+module.exports = require('../Model').extend({
+  properties: {
+    host: {
+      type: String,
+      description: 'Host that this Redis Cluster node runs on',
+      default: '127.0.0.1'
+    },
+    port: {
+      type: Number,
+      description: 'Port that this Redis Cluster node runs on'
+    }
+  }
+})

--- a/models/util/getCleanArray.js
+++ b/models/util/getCleanArray.js
@@ -1,0 +1,16 @@
+const Model = require('../Model')
+
+/**
+* Used for returning an array with models that are all cleaned
+*/
+module.exports = function getCleanArray (arr) {
+  let cleaned = []
+  arr.forEach((node) => {
+    if (Model.isModel(node)) {
+      cleaned.push(node.clean())
+    } else {
+      cleaned.push(node)
+    }
+  })
+  return cleaned
+}

--- a/test/unit/cache/Cache-test.js
+++ b/test/unit/cache/Cache-test.js
@@ -9,6 +9,7 @@ proxyquire.noPreserveCache()
 const msgpack = require('msgpack-lite')
 const MockRedisClient = require('~/test/util/mocks/MockRedisClient')
 const Model = require('~/models/Model')
+const RedisClusterNodeConfig = require('~/models/cache/RedisClusterNodeConfig')
 
 const waitForEvent = require('~/test/util/waitForEvent')
 
@@ -43,7 +44,7 @@ test.beforeEach(async (t) => {
     }
   })
 
-  t.context = { mockClient, cache, sandbox, TestModel }
+  t.context = { mockClient, cache, sandbox, TestModel, Cache }
 })
 
 test.afterEach(async (t) => {
@@ -272,4 +273,22 @@ test('should reject if there was an error diconnecting after ' +
   } catch (err) {
     t.is(err, testError)
   }
+})
+
+test('should allow creating Cache using RedisClusterNodeConfig model', (t) => {
+  const { Cache } = t.context
+
+  let nodes = []
+
+  TEST_NODES.forEach((node) => {
+    nodes.push(new RedisClusterNodeConfig(node))
+  })
+
+  let cache = new Cache({
+    nodes,
+    logger: console,
+    defaultTtl: TEST_TTL
+  })
+
+  t.deepEqual(cache._nodes, TEST_NODES)
 })

--- a/test/unit/models/util/getCleanArray.js
+++ b/test/unit/models/util/getCleanArray.js
@@ -1,0 +1,60 @@
+require('require-self-ref')
+
+const test = require('ava')
+const Model = require('~/models/Model')
+const _getCleanArray = require('~/models/util/getCleanArray')
+
+const Person = Model.extend({
+  properties: {
+    name: String
+  }
+})
+
+const TestModel = Model.extend({
+  properties: {
+    people: [Person]
+  }
+})
+
+test('should allow cleaning model array', (t) => {
+  const testModel = new TestModel({
+    people: [{
+      name: 'John'
+    }, {
+      name: 'Sally'
+    }]
+  })
+
+  t.deepEqual(_getCleanArray(testModel.getPeople()), [
+    { name: 'John' },
+    { name: 'Sally' }
+  ])
+})
+
+test('should allow cleaning array without models', (t) => {
+  const arr = [
+    { name: 'John' },
+    { name: 'Sally' }
+  ]
+
+  t.deepEqual(_getCleanArray(arr), [
+    { name: 'John' },
+    { name: 'Sally' }
+  ])
+})
+
+test('should allow cleaning array mixed with models and non-models', (t) => {
+  const person = new Person({
+    name: 'John'
+  })
+
+  const arr = [
+    person,
+    { name: 'Sally' }
+  ]
+
+  t.deepEqual(_getCleanArray(arr), [
+    { name: 'John' },
+    { name: 'Sally' }
+  ])
+})


### PR DESCRIPTION
**Service config**
```js
const BaseConfig = require('windbreaker-service-util/models/BaseServiceConfig')
const RedisClusterNodeConfig = require('windbreaker-service-util/models/cache/RedisClusterNodeConfig')

module.exports = BaseConfig.extend({
  properties: {
    ...
    redisClusterNodes: [RedisClusterNodeConfig],
    ...
  }
})
```

**Connecting to Redis**
```js
await createCache({
  ...
  nodes: config.getRedisClusterNodes()
  ...
})
```
