### PR TITLE
[WB-44] remove explicit config load function

### DIFF
--- a/config/index.js
+++ b/config/index.js
@@ -34,32 +34,31 @@ function printConfig (config) {
 *    ]
 *
 */
-module.exports = function ({ config, path: overridePath, overrides }) {
+module.exports = async function ({ config, path: overridePath, overrides }) {
   assert(!overrides || Array.isArray(overrides),
     'if present, overrides must be an array')
 
-  config.load = async function () {
-    if (config.applyDefaults) {
-      config.applyDefaults()
-    }
-
-    let allOverrides = {}
-    if (overridePath) {
-      const serviceEnv = BaseServiceConfig.getServiceEnvironment()
-      const env = (serviceEnv && serviceEnv.toLowerCase()) || 'localhost'
-      allOverrides = await confugu.load(path.join(overridePath, `${env}.yml`))
-    }
-
-    if (overrides) {
-      Object.assign(allOverrides, ...overrides)
-    }
-
-    for (const key in allOverrides) {
-      config.set(key, allOverrides[key])
-    }
-
-    printConfig(config)
-    // force config to be immutable
-    Object.freeze(config)
+  if (config.applyDefaults) {
+    config.applyDefaults()
   }
+
+  let allOverrides = {}
+  if (overridePath) {
+    const serviceEnv = BaseServiceConfig.getServiceEnvironment()
+    const env = (serviceEnv && serviceEnv.toLowerCase()) || 'localhost'
+    allOverrides = await confugu.load(path.join(overridePath, `${env}.yml`))
+  }
+
+  if (overrides) {
+    Object.assign(allOverrides, ...overrides)
+  }
+
+  for (const key in allOverrides) {
+    config.set(key, allOverrides[key])
+  }
+
+  printConfig(config)
+  // force config to be immutable
+  Object.freeze(config)
+  return config
 }

--- a/config/index.js
+++ b/config/index.js
@@ -16,9 +16,7 @@ function printConfig (config) {
 }
 
 /**
-* Patches the `Config` model instance to contain a `load` function, which can
-* be called when the config is ready to be loaded. Service environment env
-* variable must be set to load non-default config file.
+* Service environment env variable must be set to load non-default config file.
 *
 * @param obj.config {Config} - Instance of the `Config` model
 * @param obj.path {string} - Absolute path to config directory
@@ -34,7 +32,7 @@ function printConfig (config) {
 *    ]
 *
 */
-module.exports = async function ({ config, path: overridePath, overrides }) {
+exports.load = async function load ({ config, path: overridePath, overrides }) {
   assert(!overrides || Array.isArray(overrides),
     'if present, overrides must be an array')
 

--- a/test/integration/config/register-base-service-config-test.js
+++ b/test/integration/config/register-base-service-config-test.js
@@ -17,9 +17,7 @@ test.afterEach('restore environment', t => {
 test('should load expected default service config values when calling "load"', async t => {
   const config = new BaseServiceConfig()
 
-  registerConfig({ config })
-
-  await config.load()
+  await registerConfig({ config })
 
   t.deepEqual(config.clean(), {
     logLevel: 'INFO',
@@ -31,12 +29,10 @@ test('should load expected default service config values when calling "load"', a
 test('should load overrides arg when calling "load"', async t => {
   const config = new BaseServiceConfig()
 
-  registerConfig({
+  await registerConfig({
     config,
     overrides: [ { loggingColorsEnabled: false } ]
   })
-
-  await config.load()
 
   t.deepEqual(config.clean(), {
     logLevel: 'INFO',
@@ -49,12 +45,10 @@ test('should load overrides file when calling "load"', async t => {
   const config = new BaseServiceConfig()
   process.env.SERVICE_ENVIRONMENT = 'production'
 
-  registerConfig({
+  await registerConfig({
     config,
     path: path.resolve(__dirname, './fixtures')
   })
-
-  await config.load()
 
   t.deepEqual(config.clean(), {
     logLevel: 'INFO',
@@ -66,12 +60,10 @@ test('should load overrides file when calling "load"', async t => {
 test('should load default localhost config file when calling "load"', async t => {
   const config = new BaseServiceConfig()
 
-  registerConfig({
+  await registerConfig({
     config,
     path: path.resolve(__dirname, './fixtures')
   })
-
-  await config.load()
 
   t.deepEqual(config.clean(), {
     logLevel: 'ERROR',
@@ -85,12 +77,10 @@ test('should load overrides file and inject env vars when calling "load"', async
   process.env.SERVICE_ENVIRONMENT = 'production-env'
   process.env.LOGGING_COLORS_ENABLED = false
 
-  registerConfig({
+  await registerConfig({
     config,
     path: path.resolve(__dirname, './fixtures')
   })
-
-  await config.load()
 
   t.deepEqual(config.clean(), {
     logLevel: 'INFO',
@@ -103,7 +93,7 @@ test('should prefer overrides arg over file when calling "load"', async t => {
   const config = new BaseServiceConfig()
   process.env.SERVICE_ENVIRONMENT = 'production'
 
-  registerConfig({
+  await registerConfig({
     config,
     path: path.resolve(__dirname, './fixtures'),
     overrides: [
@@ -112,8 +102,6 @@ test('should prefer overrides arg over file when calling "load"', async t => {
       }
     ]
   })
-
-  await config.load()
 
   t.deepEqual(config.clean(), {
     logLevel: 'INFO',

--- a/test/integration/config/register-base-service-config-test.js
+++ b/test/integration/config/register-base-service-config-test.js
@@ -2,7 +2,7 @@ require('require-self-ref')
 
 const { test } = require('ava')
 const path = require('path')
-const registerConfig = require('~/config')
+const configUtil = require('~/config')
 const BaseServiceConfig = require('~/models/BaseServiceConfig')
 
 test.beforeEach('store environment', t => {
@@ -17,7 +17,7 @@ test.afterEach('restore environment', t => {
 test('should load expected default service config values when calling "load"', async t => {
   const config = new BaseServiceConfig()
 
-  await registerConfig({ config })
+  await configUtil.load({ config })
 
   t.deepEqual(config.clean(), {
     logLevel: 'INFO',
@@ -29,7 +29,7 @@ test('should load expected default service config values when calling "load"', a
 test('should load overrides arg when calling "load"', async t => {
   const config = new BaseServiceConfig()
 
-  await registerConfig({
+  await configUtil.load({
     config,
     overrides: [ { loggingColorsEnabled: false } ]
   })
@@ -45,7 +45,7 @@ test('should load overrides file when calling "load"', async t => {
   const config = new BaseServiceConfig()
   process.env.SERVICE_ENVIRONMENT = 'production'
 
-  await registerConfig({
+  await configUtil.load({
     config,
     path: path.resolve(__dirname, './fixtures')
   })
@@ -60,7 +60,7 @@ test('should load overrides file when calling "load"', async t => {
 test('should load default localhost config file when calling "load"', async t => {
   const config = new BaseServiceConfig()
 
-  await registerConfig({
+  await configUtil.load({
     config,
     path: path.resolve(__dirname, './fixtures')
   })
@@ -77,7 +77,7 @@ test('should load overrides file and inject env vars when calling "load"', async
   process.env.SERVICE_ENVIRONMENT = 'production-env'
   process.env.LOGGING_COLORS_ENABLED = false
 
-  await registerConfig({
+  await configUtil.load({
     config,
     path: path.resolve(__dirname, './fixtures')
   })
@@ -93,7 +93,7 @@ test('should prefer overrides arg over file when calling "load"', async t => {
   const config = new BaseServiceConfig()
   process.env.SERVICE_ENVIRONMENT = 'production'
 
-  await registerConfig({
+  await configUtil.load({
     config,
     path: path.resolve(__dirname, './fixtures'),
     overrides: [

--- a/test/unit/config/config-test.js
+++ b/test/unit/config/config-test.js
@@ -1,7 +1,8 @@
 require('require-self-ref')
 
 const { test } = require('ava')
-const registerConfig = require('~/config')
+const proxyquire = require('proxyquire')
+const sinon = require('sinon')
 const DefaultsMixin = require('fashion-model-defaults')
 
 const configOptions = {
@@ -19,20 +20,20 @@ const ConfigDefaults = Config.extend({
   mixins: [DefaultsMixin]
 })
 
-test('should add "load" function to config instance', t => {
-  const config = new Config()
-  registerConfig({ config })
-  t.is(typeof config.load, 'function')
+test.beforeEach(t => {
+  t.context.registerConfig = proxyquire('~/config', {
+    confugu: {
+      load: sinon.stub().resolves({})
+    }
+  })
 })
 
-test('should load config when calling "load"', async t => {
+test('should register config when called', async t => {
   const config = new Config({
     colors: false
   })
 
-  registerConfig({ config })
-
-  await config.load()
+  await t.context.registerConfig({ config })
 
   t.deepEqual(config.clean(), {
     colors: false
@@ -42,9 +43,7 @@ test('should load config when calling "load"', async t => {
 test('should apply defaults to a model that has the defaults mixin', async t => {
   const config = new ConfigDefaults()
 
-  registerConfig({ config })
-
-  await config.load()
+  await t.context.registerConfig({ config })
 
   t.deepEqual(config.clean(), {
     colors: true
@@ -54,7 +53,7 @@ test('should apply defaults to a model that has the defaults mixin', async t => 
 test('should allow passing array of overrides', async t => {
   const config = new ConfigDefaults()
 
-  registerConfig({
+  await t.context.registerConfig({
     config,
     overrides: [
       {
@@ -66,42 +65,39 @@ test('should allow passing array of overrides', async t => {
     ]
   })
 
-  await config.load()
-
   t.deepEqual(config.clean(), {
     colors: false,
     environment: 'PRODUCTION'
   })
 })
 
-test('should enforce overrides being undefined or array', t => {
+test('should enforce overrides being undefined or array', async t => {
   const config = new ConfigDefaults()
-  const boundRegister = registerConfig.bind(null,
+  const thrownError = await t.throws(t.context.registerConfig(
     {
       config,
       path: 'tomorrowland/2018/is/happening',
       overrides: { this: 'shouldFail' }
     }
-  )
+  ))
 
-  const thrownError = t.throws(boundRegister)
   t.is(thrownError.message, 'if present, overrides must be an array')
 })
 
-test('should allow config directory to be omitted', t => {
+test('should allow config directory to be omitted', async t => {
   const config = new ConfigDefaults()
-  registerConfig({ config, overrides: [ { this: 'shouldPass' } ] })
+  await t.context.registerConfig({ config, overrides: [ { colors: true } ] })
   t.pass()
 })
 
-test('should allow overrides to be omitted', t => {
+test('should allow overrides to be omitted', async t => {
   const config = new ConfigDefaults()
-  registerConfig({ config, path: 'tomorrowland/2018/is/happening' })
+  await t.context.registerConfig({ config, path: 'tomorrowland/2018/is/happening' })
   t.pass()
 })
 
-test('should allow overrides and config directory to be omitted', t => {
+test('should allow overrides and config directory to be omitted', async t => {
   const config = new ConfigDefaults()
-  registerConfig({ config })
+  await t.context.registerConfig({ config })
   t.pass()
 })

--- a/test/unit/config/config-test.js
+++ b/test/unit/config/config-test.js
@@ -21,7 +21,7 @@ const ConfigDefaults = Config.extend({
 })
 
 test.beforeEach(t => {
-  t.context.registerConfig = proxyquire('~/config', {
+  t.context.configUtil = proxyquire('~/config', {
     confugu: {
       load: sinon.stub().resolves({})
     }
@@ -33,7 +33,7 @@ test('should register config when called', async t => {
     colors: false
   })
 
-  await t.context.registerConfig({ config })
+  await t.context.configUtil.load({ config })
 
   t.deepEqual(config.clean(), {
     colors: false
@@ -43,7 +43,7 @@ test('should register config when called', async t => {
 test('should apply defaults to a model that has the defaults mixin', async t => {
   const config = new ConfigDefaults()
 
-  await t.context.registerConfig({ config })
+  await t.context.configUtil.load({ config })
 
   t.deepEqual(config.clean(), {
     colors: true
@@ -53,7 +53,7 @@ test('should apply defaults to a model that has the defaults mixin', async t => 
 test('should allow passing array of overrides', async t => {
   const config = new ConfigDefaults()
 
-  await t.context.registerConfig({
+  await t.context.configUtil.load({
     config,
     overrides: [
       {
@@ -73,7 +73,7 @@ test('should allow passing array of overrides', async t => {
 
 test('should enforce overrides being undefined or array', async t => {
   const config = new ConfigDefaults()
-  const thrownError = await t.throws(t.context.registerConfig(
+  const thrownError = await t.throws(t.context.configUtil.load(
     {
       config,
       path: 'tomorrowland/2018/is/happening',
@@ -86,18 +86,18 @@ test('should enforce overrides being undefined or array', async t => {
 
 test('should allow config directory to be omitted', async t => {
   const config = new ConfigDefaults()
-  await t.context.registerConfig({ config, overrides: [ { colors: true } ] })
+  await t.context.configUtil.load({ config, overrides: [ { colors: true } ] })
   t.pass()
 })
 
 test('should allow overrides to be omitted', async t => {
   const config = new ConfigDefaults()
-  await t.context.registerConfig({ config, path: 'tomorrowland/2018/is/happening' })
+  await t.context.configUtil.load({ config, path: 'tomorrowland/2018/is/happening' })
   t.pass()
 })
 
 test('should allow overrides and config directory to be omitted', async t => {
   const config = new ConfigDefaults()
-  await t.context.registerConfig({ config })
+  await t.context.configUtil.load({ config })
   t.pass()
 })


### PR DESCRIPTION
As requested from the last PR - remove .load since it's always called immediately after. No need to wait. 