### PR TITLE
[WB-25] Add test env for test specific config

### DIFF
--- a/models/Environment.js
+++ b/models/Environment.js
@@ -2,7 +2,8 @@ module.exports = require('./Enum').create({
   values: [
     'DOCKER',
     'LOCALHOST',
-    'PRODUCTION'
+    'PRODUCTION',
+    'TEST'
   ],
   autoUpperCase: true
 })


### PR DESCRIPTION
Noticed I need to start referencing alternative paths for fake secrets, etc in tests. The other alternative was a bunch of env vars in docker-compose, but that felt wrong.