### PR TITLE
[NO-ISSUE] Move migrations table name into Knex config

### DIFF
--- a/config/index.js
+++ b/config/index.js
@@ -7,13 +7,8 @@ const Environment = require('~/models/Environment')
 const path = require('path')
 
 function printConfig (config) {
-  // print config values
   console.log('Config values:')
-  const configObj = config.clean()
-  for (const key in configObj) {
-    console.log(`  ${key}: ${configObj[key]}`)
-  }
-  console.log('\n')
+  console.log(JSON.stringify(config.clean(), null, 2), '\n')
 }
 
 function applyOverrides ({ config, env, allOverrides, overrides }) {

--- a/models/dao/KnexConfig.js
+++ b/models/dao/KnexConfig.js
@@ -12,6 +12,12 @@ module.exports = require('../Model').extend({
       type: Boolean,
       description: 'Run Knex in debug mode',
       default: false
+    },
+    migrations: {
+      tableName: {
+        description: 'The database table name for running migrations',
+        default: 'migrations'
+      }
     }
   }
 })

--- a/models/dao/KnexConfig.js
+++ b/models/dao/KnexConfig.js
@@ -14,9 +14,10 @@ module.exports = require('../Model').extend({
       default: false
     },
     migrations: {
-      tableName: {
-        description: 'The database table name for running migrations',
-        default: 'migrations'
+      type: Object,
+      description: 'Migrations config object',
+      default: {
+        tableName: 'migrations'
       }
     }
   }

--- a/models/dao/KnexConfig.js
+++ b/models/dao/KnexConfig.js
@@ -1,4 +1,5 @@
 const KnexConnection = require('./KnexConnection')
+const KnexMigrations = require('./KnexMigrations')
 
 module.exports = require('../Model').extend({
   properties: {
@@ -13,12 +14,6 @@ module.exports = require('../Model').extend({
       description: 'Run Knex in debug mode',
       default: false
     },
-    migrations: {
-      type: Object,
-      description: 'Migrations config object',
-      default: {
-        tableName: 'migrations'
-      }
-    }
+    migrations: KnexMigrations
   }
 })

--- a/models/dao/KnexMigrations.js
+++ b/models/dao/KnexMigrations.js
@@ -1,0 +1,9 @@
+module.exports = require('../Model').extend({
+  properties: {
+    tableName: {
+      type: String,
+      description: 'name of the table to hold knex migration data',
+      default: 'migrations'
+    }
+  }
+})


### PR DESCRIPTION
After agreeing that we'd use separate databases for each service, it makes sense to move this config to the shared model. Each db e.g. `windbreaker-core`, `windbreaker-hooks`, will have it's own `migrations` table.